### PR TITLE
Update & complete french calendars 2015-2025

### DIFF
--- a/src/main/resources/calendars/i18n_fr.calendar
+++ b/src/main/resources/calendars/i18n_fr.calendar
@@ -1,89 +1,72 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<calendar id="france" name="France National Holidays 2008-2021" type="country">
-<!-- http://www.officeholidays.com/countries/france/ -->
-    <date year="" month="1" date="1" type="HOLIDAY"><![CDATA[New Year's Day]]></date>
-    <date year="" month="5" date="1" type="HOLIDAY"><![CDATA[Labour Day]]></date>
-    <date year="" month="5" date="8" type="HOLIDAY"><![CDATA[V-E Day]]></date>
-    <date year="" month="7" date="14" type="HOLIDAY"><![CDATA[Bastille Day]]></date>
-    <date year="" month="8" date="15" type="HOLIDAY"><![CDATA[Assumption Day]]></date>
-    <date year="" month="11" date="1" type="HOLIDAY"><![CDATA[All Saints Day]]></date>
-    <date year="" month="11" date="11" type="HOLIDAY"><![CDATA[Armistice Day]]></date>
-    <date year="" month="12" date="25" type="HOLIDAY"><![CDATA[Christmas Day]]></date>
+<calendar id="fr" name="France National Holidays 2015-2025" type="country">
+    <!-- http://www.officeholidays.com/countries/france/ -->
+    <!-- and official french gouv api https://api.gouv.fr/les-api/jours-feries -->
 
-    <date year="2008" month="5" date="12" type="HOLIDAY"><![CDATA[Whitmonday]]></date>
-    <date year="2009" month="6" date="1" type="HOLIDAY"><![CDATA[Whitmonday]]></date>
-    <date year="2009" month="7" date="13" type="NEUTRAL"><![CDATA[Bastille Day]]></date>
-    <date year="2010" month="4" date="5" type="HOLIDAY"><![CDATA[Easter Monday]]></date>
-    <date year="2010" month="5" date="13" type="HOLIDAY"><![CDATA[Ascension Day]]></date>
-    <date year="2010" month="5" date="24" type="HOLIDAY"><![CDATA[Whitmonday]]></date>
+    <!-- recurring -->
+    <date year="" month="1" date="1" type="HOLIDAY"><![CDATA[1er janvier]]></date>
+    <date year="" month="5" date="1" type="HOLIDAY"><![CDATA[1er mai]]></date>
+    <date year="" month="5" date="8" type="HOLIDAY"><![CDATA[8 mai]]></date>
+    <date year="" month="7" date="14" type="HOLIDAY"><![CDATA[14 juillet]]></date>
+    <date year="" month="8" date="15" type="HOLIDAY"><![CDATA[Assomption]]></date>
+    <date year="" month="11" date="1" type="HOLIDAY"><![CDATA[Toussaint]]></date>
+    <date year="" month="11" date="11" type="HOLIDAY"><![CDATA[11 novembre]]></date>
+    <date year="" month="12" date="25" type="HOLIDAY"><![CDATA[Jour de Noël]]></date>
 
-    <date year="2011" month="4" date="25" type="HOLIDAY"><![CDATA[Easter Monday]]></date>
-    <date year="2011" month="5" date="29" type="NEUTRAL"><![CDATA[Mothers Day]]></date>
-    <date year="2011" month="6" date="2" type="HOLIDAY"><![CDATA[Ascension Day]]></date>
-    <date year="2011" month="6" date="13" type="HOLIDAY"><![CDATA[Whitmonday]]></date>
-    <date year="2011" month="6" date="19" type="NEUTRAL"><![CDATA[Fathers Day]]></date>
 
-    <date year="2012" month="1" date="2" type="HOLIDAY"><![CDATA[New Years Day (in lieu)]]></date>
-    <date year="2012" month="4" date="9" type="HOLIDAY"><![CDATA[Easter Monday]]></date>
-    <date year="2012" month="5" date="17" type="HOLIDAY"><![CDATA[Ascension Day]]></date>
-    <date year="2012" month="5" date="28" type="HOLIDAY"><![CDATA[Whitmonday]]></date>
-    <date year="2012" month="6" date="3" type="NEUTRAL"><![CDATA[Mothers Day]]></date>
-    <date year="2012" month="6" date="17" type="NEUTRAL"><![CDATA[Fathers Day]]></date>
-    <date year="2012" month="11" date="12" type="HOLIDAY"><![CDATA[Armistice Day (in Lieu)]]></date>
-    <date year="2012" month="12" date="25" type="HOLIDAY"><![CDATA[Christmas Day]]></date>
+    <!-- 2015 -->
+    <date year="2015" month="4" date="6" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2015" month="5" date="14" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2015" month="5" date="25" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
 
-    <date year="2013" month="4" date="1" type="HOLIDAY"><![CDATA[Easter Monday]]></date>
-    <date year="2013" month="5" date="9" type="HOLIDAY"><![CDATA[Ascension Day]]></date>
-    <date year="2013" month="5" date="20" type="HOLIDAY"><![CDATA[Whitmonday]]></date>
-    <date year="2013" month="5" date="26" type="NEUTRAL"><![CDATA[Mothers Day]]></date>
-    <date year="2013" month="6" date="16" type="NEUTRAL"><![CDATA[Fathers Day]]></date>
+    <!-- 2016 -->
+    <date year="2016" month="3" date="28" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2016" month="5" date="5" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2016" month="5" date="16" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
 
-    <date year="2014" month="4" date="21" type="HOLIDAY"><![CDATA[Easter Monday]]></date>
-    <date year="2014" month="5" date="25" type="NEUTRAL"><![CDATA[Mothers Day]]></date>
-    <date year="2014" month="5" date="29" type="NEUTRAL"><![CDATA[Ascension Day]]></date>
-    <date year="2014" month="6" date="9" type="HOLIDAY"><![CDATA[Whitmonday]]></date>
-    <date year="2014" month="6" date="15" type="HOLIDAY"><![CDATA[Fathers Day]]></date>
+    <!-- 2017 -->
+    <date year="2017" month="4" date="17" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2017" month="5" date="25" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2017" month="6" date="5" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
 
-    <date year="2015" month="4" date="6" type="HOLIDAY"><![CDATA[Easter Monday]]></date>
-    <date year="2015" month="5" date="14" type="HOLIDAY"><![CDATA[Ascension Day]]></date>
-    <date year="2015" month="5" date="24" type="NEUTRAL"><![CDATA[Mothers Day]]></date>
-    <date year="2015" month="5" date="25" type="HOLIDAY"><![CDATA[Whitmonday]]></date>
-    <date year="2015" month="6" date="21" type="NEUTRAL"><![CDATA[Fathers Day]]></date>
+    <!-- 2018 -->
+    <date year="2018" month="4" date="2" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2018" month="5" date="10" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2018" month="5" date="21" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
 
-    <date year="2016" month="3" date="28" type="HOLIDAY"><![CDATA[Easter Monday]]></date>
-    <date year="2016" month="5" date="5" type="HOLIDAY"><![CDATA[Ascension Day]]></date>
-    <date year="2016" month="5" date="16" type="HOLIDAY"><![CDATA[Whitmonday]]></date>
-    <date year="2016" month="5" date="29" type="NEUTRAL"><![CDATA[Mothers Day]]></date>
-    <date year="2016" month="6" date="19" type="NEUTRAL"><![CDATA[Fathers Day]]></date>
-    <date year="2016" month="12" date="26" type="HOLIDAY"><![CDATA[Christmas Day (observed)]]></date>
+    <!-- 2019 -->
+    <date year="2019" month="4" date="22" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2019" month="5" date="30" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2019" month="6" date="10" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
 
-    <date year="2017" month="4" date="17" type="HOLIDAY"><![CDATA[Easter Monday]]></date>
-    <date year="2017" month="5" date="25" type="HOLIDAY"><![CDATA[Ascension Day]]></date>
-    <date year="2017" month="5" date="28" type="NEUTRAL"><![CDATA[Mother's Day]]></date>
-    <date year="2017" month="6" date="5" type="HOLIDAY"><![CDATA[Whitmonday]]></date>
-    <date year="2017" month="6" date="18" type="NEUTRAL"><![CDATA[Father's Day]]></date>
+    <!-- 2020 -->
+    <date year="2020" month="4" date="13" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2020" month="5" date="21" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2020" month="6" date="1" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
 
-    <date year="2018" month="4" date="2" type="HOLIDAY"><![CDATA[Easter Monday]]></date>
-    <date year="2018" month="5" date="10" type="HOLIDAY"><![CDATA[Ascension Day]]></date>
-    <date year="2018" month="5" date="21" type="HOLIDAY"><![CDATA[Whit Monday]]></date>
-    <date year="2018" month="5" date="27" type="NEUTRAL"><![CDATA[Mother's Day]]></date>
-    <date year="2018" month="6" date="17" type="NEUTRAL"><![CDATA[Father's Day]]></date>
+    <!-- 2021 -->
+    <date year="2021" month="4" date="5" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2021" month="5" date="13" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2021" month="5" date="24" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
 
-    <date year="2019" month="4" date="22" type="HOLIDAY"><![CDATA[Easter Monday]]></date>
-    <date year="2019" month="5" date="30" type="HOLIDAY"><![CDATA[Ascension Day]]></date>
-    <date year="2019" month="6" date="10" type="HOLIDAY"><![CDATA[Whit Monday]]></date>
-    <date year="2019" month="5" date="26" type="NEUTRAL"><![CDATA[Mother's Day]]></date>
-    <date year="2019" month="6" date="16" type="NEUTRAL"><![CDATA[Father's Day]]></date>
+    <!-- 2022 -->
+    <date year="2022" month="4" date="18" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2022" month="5" date="26" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2022" month="6" date="6" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
 
-    <date year="2020" month="4" date="13" type="HOLIDAY"><![CDATA[Easter Monday]]></date>
-    <date year="2020" month="5" date="21" type="HOLIDAY"><![CDATA[Ascension Day]]></date>
-    <date year="2020" month="6" date="1" type="HOLIDAY"><![CDATA[Whit Monday]]></date>
-    <date year="2020" month="6" date="7" type="NEUTRAL"><![CDATA[Mother's Day]]></date>
-    <date year="2020" month="6" date="21" type="NEUTRAL"><![CDATA[Father's Day]]></date>
+    <!-- 2023 -->
+    <date year="2023" month="4" date="10" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2023" month="5" date="18" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2023" month="5" date="29" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
 
-    <date year="2021" month="4" date="5" type="HOLIDAY"><![CDATA[Easter Monday]]></date>
-    <date year="2021" month="5" date="13" type="HOLIDAY"><![CDATA[Ascension Day]]></date>
-    <date year="2021" month="5" date="24" type="HOLIDAY"><![CDATA[Whit Monday]]></date>
-    <date year="2021" month="5" date="30" type="NEUTRAL"><![CDATA[Mother's Day]]></date>
-    <date year="2021" month="6" date="20" type="NEUTRAL"><![CDATA[Father's Day]]></date>
+    <!-- 2024 -->
+    <date year="2024" month="4" date="1" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2024" month="5" date="9" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2024" month="5" date="20" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2025 -->
+    <date year="2025" month="4" date="21" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2025" month="5" date="29" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2025" month="6" date="9" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
 </calendar>

--- a/src/main/resources/calendars/i18n_fr_alsace_moselle.calendar
+++ b/src/main/resources/calendars/i18n_fr_alsace_moselle.calendar
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<calendar id="fr.alsace-moselle" name="France (Alsace-Moselle) National Holidays 2015-2025" type="country">
+<!-- http://www.officeholidays.com/countries/france/ -->
+<!-- and official french gouv api https://api.gouv.fr/les-api/jours-feries -->
+
+    <!-- recurring -->
+    <date year="" month="1" date="1" type="HOLIDAY"><![CDATA[1er janvier]]></date>
+    <date year="" month="5" date="1" type="HOLIDAY"><![CDATA[1er mai]]></date>
+    <date year="" month="5" date="8" type="HOLIDAY"><![CDATA[8 mai]]></date>
+    <date year="" month="7" date="14" type="HOLIDAY"><![CDATA[14 juillet]]></date>
+    <date year="" month="8" date="15" type="HOLIDAY"><![CDATA[Assomption]]></date>
+    <date year="" month="11" date="1" type="HOLIDAY"><![CDATA[Toussaint]]></date>
+    <date year="" month="11" date="11" type="HOLIDAY"><![CDATA[11 novembre]]></date>
+    <date year="" month="12" date="25" type="HOLIDAY"><![CDATA[Jour de Noël]]></date>
+    <date year="" month="12" date="26" type="HOLIDAY"><![CDATA[2ème jour de Noël]]></date>
+
+    <!-- 2015 -->
+    <date year="2015" month="4" date="3" type="HOLIDAY"><![CDATA[Vendredi saint]]></date>
+    <date year="2015" month="4" date="6" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2015" month="5" date="14" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2015" month="5" date="25" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2016 -->
+    <date year="2016" month="3" date="25" type="HOLIDAY"><![CDATA[Vendredi saint]]></date>
+    <date year="2016" month="3" date="28" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2016" month="5" date="5" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2016" month="5" date="16" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2017 -->
+    <date year="2017" month="4" date="14" type="HOLIDAY"><![CDATA[Vendredi saint]]></date>
+    <date year="2017" month="4" date="17" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2017" month="5" date="25" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2017" month="6" date="5" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2018 -->
+    <date year="2018" month="3" date="30" type="HOLIDAY"><![CDATA[Vendredi saint]]></date>
+    <date year="2018" month="4" date="2" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2018" month="5" date="10" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2018" month="5" date="21" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2019 -->
+    <date year="2019" month="4" date="19" type="HOLIDAY"><![CDATA[Vendredi saint]]></date>
+    <date year="2019" month="4" date="22" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2019" month="5" date="30" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2019" month="6" date="10" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2020 -->
+    <date year="2020" month="4" date="10" type="HOLIDAY"><![CDATA[Vendredi saint]]></date>
+    <date year="2020" month="4" date="13" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2020" month="5" date="21" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2020" month="6" date="1" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2021 -->
+    <date year="2021" month="4" date="2" type="HOLIDAY"><![CDATA[Vendredi saint]]></date>
+    <date year="2021" month="4" date="5" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2021" month="5" date="13" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2021" month="5" date="24" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2022 -->
+    <date year="2022" month="4" date="15" type="HOLIDAY"><![CDATA[Vendredi saint]]></date>
+    <date year="2022" month="4" date="18" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2022" month="5" date="26" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2022" month="6" date="6" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2023 -->
+    <date year="2023" month="4" date="7" type="HOLIDAY"><![CDATA[Vendredi saint]]></date>
+    <date year="2023" month="4" date="10" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2023" month="5" date="18" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2023" month="5" date="29" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2024 -->
+    <date year="2024" month="3" date="29" type="HOLIDAY"><![CDATA[Vendredi saint]]></date>
+    <date year="2024" month="4" date="1" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2024" month="5" date="9" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2024" month="5" date="20" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2025 -->
+    <date year="2025" month="4" date="18" type="HOLIDAY"><![CDATA[Vendredi saint]]></date>
+    <date year="2025" month="4" date="21" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2025" month="5" date="29" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2025" month="6" date="9" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+</calendar>

--- a/src/main/resources/calendars/i18n_fr_guadeloupe.calendar
+++ b/src/main/resources/calendars/i18n_fr_guadeloupe.calendar
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<calendar id="fr.guadeloupe" name="France (Guadeloupe) National Holidays 2015-2025" type="country">
+    <!-- http://www.officeholidays.com/countries/france/ -->
+    <!-- and official french gouv api https://api.gouv.fr/les-api/jours-feries -->
+
+    <!-- recurring -->
+    <date year="" month="1" date="1" type="HOLIDAY"><![CDATA[1er janvier]]></date>
+    <date year="" month="5" date="1" type="HOLIDAY"><![CDATA[1er mai]]></date>
+    <date year="" month="5" date="8" type="HOLIDAY"><![CDATA[8 mai]]></date>
+    <date year="" month="5" date="27" type="HOLIDAY"><![CDATA[Abolition de l'esclavage]]></date>
+    <date year="" month="7" date="14" type="HOLIDAY"><![CDATA[14 juillet]]></date>
+    <date year="" month="8" date="15" type="HOLIDAY"><![CDATA[Assomption]]></date>
+    <date year="" month="11" date="1" type="HOLIDAY"><![CDATA[Toussaint]]></date>
+    <date year="" month="11" date="11" type="HOLIDAY"><![CDATA[11 novembre]]></date>
+    <date year="" month="12" date="25" type="HOLIDAY"><![CDATA[Jour de Noël]]></date>
+
+
+    <!-- 2015 -->
+    <date year="2015" month="4" date="6" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2015" month="5" date="14" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2015" month="5" date="25" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2016 -->
+    <date year="2016" month="3" date="28" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2016" month="5" date="5" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2016" month="5" date="16" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2017 -->
+    <date year="2017" month="4" date="17" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2017" month="5" date="25" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2017" month="6" date="5" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2018 -->
+    <date year="2018" month="4" date="2" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2018" month="5" date="10" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2018" month="5" date="21" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2019 -->
+    <date year="2019" month="4" date="22" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2019" month="5" date="30" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2019" month="6" date="10" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2020 -->
+    <date year="2020" month="4" date="13" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2020" month="5" date="21" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2020" month="6" date="1" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2021 -->
+    <date year="2021" month="4" date="5" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2021" month="5" date="13" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2021" month="5" date="24" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2022 -->
+    <date year="2022" month="4" date="18" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2022" month="5" date="26" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2022" month="6" date="6" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2023 -->
+    <date year="2023" month="4" date="10" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2023" month="5" date="18" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2023" month="5" date="29" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2024 -->
+    <date year="2024" month="4" date="1" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2024" month="5" date="9" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2024" month="5" date="20" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2025 -->
+    <date year="2025" month="4" date="21" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2025" month="5" date="29" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2025" month="6" date="9" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+</calendar>

--- a/src/main/resources/calendars/i18n_fr_guyane.calendar
+++ b/src/main/resources/calendars/i18n_fr_guyane.calendar
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<calendar id="fr.guyane" name="France (Guyane) National Holidays 2015-2025" type="country">
+    <!-- http://www.officeholidays.com/countries/france/ -->
+    <!-- and official french gouv api https://api.gouv.fr/les-api/jours-feries -->
+
+    <!-- recurring -->
+    <date year="" month="1" date="1" type="HOLIDAY"><![CDATA[1er janvier]]></date>
+    <date year="" month="5" date="1" type="HOLIDAY"><![CDATA[1er mai]]></date>
+    <date year="" month="5" date="8" type="HOLIDAY"><![CDATA[8 mai]]></date>
+    <date year="" month="6" date="10" type="HOLIDAY"><![CDATA[Abolition de l'esclavage]]></date>
+    <date year="" month="7" date="14" type="HOLIDAY"><![CDATA[14 juillet]]></date>
+    <date year="" month="8" date="15" type="HOLIDAY"><![CDATA[Assomption]]></date>
+    <date year="" month="11" date="1" type="HOLIDAY"><![CDATA[Toussaint]]></date>
+    <date year="" month="11" date="11" type="HOLIDAY"><![CDATA[11 novembre]]></date>
+    <date year="" month="12" date="25" type="HOLIDAY"><![CDATA[Jour de Noël]]></date>
+
+
+    <!-- 2015 -->
+    <date year="2015" month="4" date="6" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2015" month="5" date="14" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2015" month="5" date="25" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2016 -->
+    <date year="2016" month="3" date="28" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2016" month="5" date="5" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2016" month="5" date="16" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2017 -->
+    <date year="2017" month="4" date="17" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2017" month="5" date="25" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2017" month="6" date="5" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2018 -->
+    <date year="2018" month="4" date="2" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2018" month="5" date="10" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2018" month="5" date="21" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2019 -->
+    <date year="2019" month="4" date="22" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2019" month="5" date="30" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2019" month="6" date="10" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2020 -->
+    <date year="2020" month="4" date="13" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2020" month="5" date="21" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2020" month="6" date="1" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2021 -->
+    <date year="2021" month="4" date="5" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2021" month="5" date="13" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2021" month="5" date="24" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2022 -->
+    <date year="2022" month="4" date="18" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2022" month="5" date="26" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2022" month="6" date="6" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2023 -->
+    <date year="2023" month="4" date="10" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2023" month="5" date="18" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2023" month="5" date="29" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2024 -->
+    <date year="2024" month="4" date="1" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2024" month="5" date="9" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2024" month="5" date="20" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2025 -->
+    <date year="2025" month="4" date="21" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2025" month="5" date="29" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2025" month="6" date="9" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+</calendar>

--- a/src/main/resources/calendars/i18n_fr_la_reunion.calendar
+++ b/src/main/resources/calendars/i18n_fr_la_reunion.calendar
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<calendar id="fr.la-reunion" name="France (La Réunion) National Holidays 2015-2025" type="country">
+    <!-- http://www.officeholidays.com/countries/france/ -->
+    <!-- and official french gouv api https://api.gouv.fr/les-api/jours-feries -->
+
+    <!-- recurring -->
+    <date year="" month="1" date="1" type="HOLIDAY"><![CDATA[1er janvier]]></date>
+    <date year="" month="5" date="1" type="HOLIDAY"><![CDATA[1er mai]]></date>
+    <date year="" month="5" date="8" type="HOLIDAY"><![CDATA[8 mai]]></date>
+    <date year="" month="7" date="14" type="HOLIDAY"><![CDATA[14 juillet]]></date>
+    <date year="" month="8" date="15" type="HOLIDAY"><![CDATA[Assomption]]></date>
+    <date year="" month="11" date="1" type="HOLIDAY"><![CDATA[Toussaint]]></date>
+    <date year="" month="11" date="11" type="HOLIDAY"><![CDATA[11 novembre]]></date>
+    <date year="" month="12" date="20" type="HOLIDAY"><![CDATA[Abolition de l'esclavage]]></date>
+    <date year="" month="12" date="25" type="HOLIDAY"><![CDATA[Jour de Noël]]></date>
+
+
+    <!-- 2015 -->
+    <date year="2015" month="4" date="6" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2015" month="5" date="14" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2015" month="5" date="25" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2016 -->
+    <date year="2016" month="3" date="28" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2016" month="5" date="5" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2016" month="5" date="16" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2017 -->
+    <date year="2017" month="4" date="17" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2017" month="5" date="25" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2017" month="6" date="5" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2018 -->
+    <date year="2018" month="4" date="2" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2018" month="5" date="10" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2018" month="5" date="21" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2019 -->
+    <date year="2019" month="4" date="22" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2019" month="5" date="30" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2019" month="6" date="10" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2020 -->
+    <date year="2020" month="4" date="13" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2020" month="5" date="21" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2020" month="6" date="1" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2021 -->
+    <date year="2021" month="4" date="5" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2021" month="5" date="13" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2021" month="5" date="24" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2022 -->
+    <date year="2022" month="4" date="18" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2022" month="5" date="26" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2022" month="6" date="6" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2023 -->
+    <date year="2023" month="4" date="10" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2023" month="5" date="18" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2023" month="5" date="29" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2024 -->
+    <date year="2024" month="4" date="1" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2024" month="5" date="9" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2024" month="5" date="20" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2025 -->
+    <date year="2025" month="4" date="21" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2025" month="5" date="29" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2025" month="6" date="9" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+</calendar>

--- a/src/main/resources/calendars/i18n_fr_martinique.calendar
+++ b/src/main/resources/calendars/i18n_fr_martinique.calendar
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<calendar id="fr.martinique" name="France (Martinique) National Holidays 2015-2025" type="country">
+    <!-- http://www.officeholidays.com/countries/france/ -->
+    <!-- and official french gouv api https://api.gouv.fr/les-api/jours-feries -->
+
+    <!-- recurring -->
+    <date year="" month="1" date="1" type="HOLIDAY"><![CDATA[1er janvier]]></date>
+    <date year="" month="5" date="1" type="HOLIDAY"><![CDATA[1er mai]]></date>
+    <date year="" month="5" date="8" type="HOLIDAY"><![CDATA[8 mai]]></date>
+    <date year="" month="5" date="22" type="HOLIDAY"><![CDATA[Abolition de l'esclavage]]></date>
+    <date year="" month="7" date="14" type="HOLIDAY"><![CDATA[14 juillet]]></date>
+    <date year="" month="8" date="15" type="HOLIDAY"><![CDATA[Assomption]]></date>
+    <date year="" month="11" date="1" type="HOLIDAY"><![CDATA[Toussaint]]></date>
+    <date year="" month="11" date="11" type="HOLIDAY"><![CDATA[11 novembre]]></date>
+    <date year="" month="12" date="25" type="HOLIDAY"><![CDATA[Jour de Noël]]></date>
+
+
+    <!-- 2015 -->
+    <date year="2015" month="4" date="6" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2015" month="5" date="14" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2015" month="5" date="25" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2016 -->
+    <date year="2016" month="3" date="28" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2016" month="5" date="5" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2016" month="5" date="16" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2017 -->
+    <date year="2017" month="4" date="17" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2017" month="5" date="25" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2017" month="6" date="5" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2018 -->
+    <date year="2018" month="4" date="2" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2018" month="5" date="10" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2018" month="5" date="21" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2019 -->
+    <date year="2019" month="4" date="22" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2019" month="5" date="30" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2019" month="6" date="10" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2020 -->
+    <date year="2020" month="4" date="13" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2020" month="5" date="21" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2020" month="6" date="1" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2021 -->
+    <date year="2021" month="4" date="5" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2021" month="5" date="13" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2021" month="5" date="24" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2022 -->
+    <date year="2022" month="4" date="18" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2022" month="5" date="26" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2022" month="6" date="6" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2023 -->
+    <date year="2023" month="4" date="10" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2023" month="5" date="18" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2023" month="5" date="29" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2024 -->
+    <date year="2024" month="4" date="1" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2024" month="5" date="9" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2024" month="5" date="20" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2025 -->
+    <date year="2025" month="4" date="21" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2025" month="5" date="29" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2025" month="6" date="9" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+</calendar>

--- a/src/main/resources/calendars/i18n_fr_mayotte.calendar
+++ b/src/main/resources/calendars/i18n_fr_mayotte.calendar
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<calendar id="fr.mayotte" name="France (Mayotte) National Holidays 2015-2025" type="country">
+    <!-- http://www.officeholidays.com/countries/france/ -->
+    <!-- and official french gouv api https://api.gouv.fr/les-api/jours-feries -->
+
+    <!-- recurring -->
+    <date year="" month="1" date="1" type="HOLIDAY"><![CDATA[1er janvier]]></date>
+    <date year="" month="4" date="27" type="HOLIDAY"><![CDATA[Abolition de l'esclavage]]></date>
+    <date year="" month="5" date="1" type="HOLIDAY"><![CDATA[1er mai]]></date>
+    <date year="" month="5" date="8" type="HOLIDAY"><![CDATA[8 mai]]></date>
+    <date year="" month="7" date="14" type="HOLIDAY"><![CDATA[14 juillet]]></date>
+    <date year="" month="8" date="15" type="HOLIDAY"><![CDATA[Assomption]]></date>
+    <date year="" month="11" date="1" type="HOLIDAY"><![CDATA[Toussaint]]></date>
+    <date year="" month="11" date="11" type="HOLIDAY"><![CDATA[11 novembre]]></date>
+    <date year="" month="12" date="25" type="HOLIDAY"><![CDATA[Jour de Noël]]></date>
+
+
+    <!-- 2015 -->
+    <date year="2015" month="4" date="6" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2015" month="5" date="14" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2015" month="5" date="25" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2016 -->
+    <date year="2016" month="3" date="28" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2016" month="5" date="5" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2016" month="5" date="16" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2017 -->
+    <date year="2017" month="4" date="17" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2017" month="5" date="25" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2017" month="6" date="5" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2018 -->
+    <date year="2018" month="4" date="2" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2018" month="5" date="10" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2018" month="5" date="21" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2019 -->
+    <date year="2019" month="4" date="22" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2019" month="5" date="30" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2019" month="6" date="10" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2020 -->
+    <date year="2020" month="4" date="13" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2020" month="5" date="21" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2020" month="6" date="1" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2021 -->
+    <date year="2021" month="4" date="5" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2021" month="5" date="13" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2021" month="5" date="24" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2022 -->
+    <date year="2022" month="4" date="18" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2022" month="5" date="26" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2022" month="6" date="6" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2023 -->
+    <date year="2023" month="4" date="10" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2023" month="5" date="18" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2023" month="5" date="29" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2024 -->
+    <date year="2024" month="4" date="1" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2024" month="5" date="9" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2024" month="5" date="20" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2025 -->
+    <date year="2025" month="4" date="21" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2025" month="5" date="29" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2025" month="6" date="9" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+</calendar>

--- a/src/main/resources/calendars/i18n_fr_nouvelle_caledonie.calendar
+++ b/src/main/resources/calendars/i18n_fr_nouvelle_caledonie.calendar
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<calendar id="fr.nouvelle-caledonie" name="France (Nouvelle-Calédonie) National Holidays 2015-2025" type="country">
+    <!-- http://www.officeholidays.com/countries/france/ -->
+    <!-- and official french gouv api https://api.gouv.fr/les-api/jours-feries -->
+
+    <!-- recurring -->
+    <date year="" month="1" date="1" type="HOLIDAY"><![CDATA[1er janvier]]></date>
+    <date year="" month="5" date="1" type="HOLIDAY"><![CDATA[1er mai]]></date>
+    <date year="" month="5" date="8" type="HOLIDAY"><![CDATA[8 mai]]></date>
+    <date year="" month="7" date="14" type="HOLIDAY"><![CDATA[14 juillet]]></date>
+    <date year="" month="8" date="15" type="HOLIDAY"><![CDATA[Assomption]]></date>
+    <date year="" month="11" date="1" type="HOLIDAY"><![CDATA[Toussaint]]></date>
+    <date year="" month="11" date="11" type="HOLIDAY"><![CDATA[11 novembre]]></date>
+    <date year="" month="12" date="25" type="HOLIDAY"><![CDATA[Jour de Noël]]></date>
+
+
+    <!-- 2015 -->
+    <date year="2015" month="4" date="6" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2015" month="5" date="14" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2015" month="5" date="25" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2016 -->
+    <date year="2016" month="3" date="28" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2016" month="5" date="5" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2016" month="5" date="16" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2017 -->
+    <date year="2017" month="4" date="17" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2017" month="5" date="25" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2017" month="6" date="5" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2018 -->
+    <date year="2018" month="4" date="2" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2018" month="5" date="10" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2018" month="5" date="21" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2019 -->
+    <date year="2019" month="4" date="22" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2019" month="5" date="30" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2019" month="6" date="10" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2020 -->
+    <date year="2020" month="4" date="13" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2020" month="5" date="21" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2020" month="6" date="1" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2021 -->
+    <date year="2021" month="4" date="5" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2021" month="5" date="13" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2021" month="5" date="24" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2022 -->
+    <date year="2022" month="4" date="18" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2022" month="5" date="26" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2022" month="6" date="6" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2023 -->
+    <date year="2023" month="4" date="10" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2023" month="5" date="18" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2023" month="5" date="29" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2024 -->
+    <date year="2024" month="4" date="1" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2024" month="5" date="9" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2024" month="5" date="20" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2025 -->
+    <date year="2025" month="4" date="21" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2025" month="5" date="29" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2025" month="6" date="9" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+</calendar>

--- a/src/main/resources/calendars/i18n_fr_polynesie_francaise.calendar
+++ b/src/main/resources/calendars/i18n_fr_polynesie_francaise.calendar
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<calendar id="fr.polynesie-francaise" name="France (Polynésie française) National Holidays 2015-2025" type="country">
+    <!-- http://www.officeholidays.com/countries/france/ -->
+    <!-- and official french gouv api https://api.gouv.fr/les-api/jours-feries -->
+
+    <!-- recurring -->
+    <date year="" month="1" date="1" type="HOLIDAY"><![CDATA[1er janvier]]></date>
+    <date year="" month="5" date="1" type="HOLIDAY"><![CDATA[1er mai]]></date>
+    <date year="" month="5" date="8" type="HOLIDAY"><![CDATA[8 mai]]></date>
+    <date year="" month="7" date="14" type="HOLIDAY"><![CDATA[14 juillet]]></date>
+    <date year="" month="8" date="15" type="HOLIDAY"><![CDATA[Assomption]]></date>
+    <date year="" month="11" date="1" type="HOLIDAY"><![CDATA[Toussaint]]></date>
+    <date year="" month="11" date="11" type="HOLIDAY"><![CDATA[11 novembre]]></date>
+    <date year="" month="12" date="25" type="HOLIDAY"><![CDATA[Jour de Noël]]></date>
+
+
+    <!-- 2015 -->
+    <date year="2015" month="4" date="6" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2015" month="5" date="14" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2015" month="5" date="25" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2016 -->
+    <date year="2016" month="3" date="28" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2016" month="5" date="5" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2016" month="5" date="16" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2017 -->
+    <date year="2017" month="4" date="17" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2017" month="5" date="25" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2017" month="6" date="5" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2018 -->
+    <date year="2018" month="4" date="2" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2018" month="5" date="10" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2018" month="5" date="21" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2019 -->
+    <date year="2019" month="4" date="22" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2019" month="5" date="30" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2019" month="6" date="10" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2020 -->
+    <date year="2020" month="4" date="13" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2020" month="5" date="21" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2020" month="6" date="1" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2021 -->
+    <date year="2021" month="4" date="5" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2021" month="5" date="13" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2021" month="5" date="24" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2022 -->
+    <date year="2022" month="4" date="18" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2022" month="5" date="26" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2022" month="6" date="6" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2023 -->
+    <date year="2023" month="4" date="10" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2023" month="5" date="18" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2023" month="5" date="29" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2024 -->
+    <date year="2024" month="4" date="1" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2024" month="5" date="9" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2024" month="5" date="20" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2025 -->
+    <date year="2025" month="4" date="21" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2025" month="5" date="29" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2025" month="6" date="9" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+</calendar>

--- a/src/main/resources/calendars/i18n_fr_saint_barthelemy.calendar
+++ b/src/main/resources/calendars/i18n_fr_saint_barthelemy.calendar
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<calendar id="fr.saint-barthelemy" name="France (Saint-Barthélemy) National Holidays 2015-2025" type="country">
+    <!-- http://www.officeholidays.com/countries/france/ -->
+    <!-- and official french gouv api https://api.gouv.fr/les-api/jours-feries -->
+
+    <!-- recurring -->
+    <date year="" month="1" date="1" type="HOLIDAY"><![CDATA[1er janvier]]></date>
+    <date year="" month="5" date="1" type="HOLIDAY"><![CDATA[1er mai]]></date>
+    <date year="" month="5" date="8" type="HOLIDAY"><![CDATA[8 mai]]></date>
+    <date year="" month="7" date="14" type="HOLIDAY"><![CDATA[14 juillet]]></date>
+    <date year="" month="8" date="15" type="HOLIDAY"><![CDATA[Assomption]]></date>
+    <date year="" month="9" date="10" type="HOLIDAY"><![CDATA[Abolition de l'esclavage]]></date>
+    <date year="" month="11" date="1" type="HOLIDAY"><![CDATA[Toussaint]]></date>
+    <date year="" month="11" date="11" type="HOLIDAY"><![CDATA[11 novembre]]></date>
+    <date year="" month="12" date="25" type="HOLIDAY"><![CDATA[Jour de Noël]]></date>
+
+
+    <!-- 2015 -->
+    <date year="2015" month="4" date="6" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2015" month="5" date="14" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2015" month="5" date="25" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2016 -->
+    <date year="2016" month="3" date="28" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2016" month="5" date="5" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2016" month="5" date="16" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2017 -->
+    <date year="2017" month="4" date="17" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2017" month="5" date="25" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2017" month="6" date="5" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2018 -->
+    <date year="2018" month="4" date="2" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2018" month="5" date="10" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2018" month="5" date="21" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2019 -->
+    <date year="2019" month="4" date="22" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2019" month="5" date="30" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2019" month="6" date="10" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2020 -->
+    <date year="2020" month="4" date="13" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2020" month="5" date="21" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2020" month="6" date="1" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2021 -->
+    <date year="2021" month="4" date="5" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2021" month="5" date="13" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2021" month="5" date="24" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2022 -->
+    <date year="2022" month="4" date="18" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2022" month="5" date="26" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2022" month="6" date="6" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2023 -->
+    <date year="2023" month="4" date="10" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2023" month="5" date="18" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2023" month="5" date="29" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2024 -->
+    <date year="2024" month="4" date="1" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2024" month="5" date="9" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2024" month="5" date="20" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2025 -->
+    <date year="2025" month="4" date="21" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2025" month="5" date="29" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2025" month="6" date="9" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+</calendar>

--- a/src/main/resources/calendars/i18n_fr_saint_martin.calendar
+++ b/src/main/resources/calendars/i18n_fr_saint_martin.calendar
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<calendar id="fr.saint-martin" name="France (Saint-Martin) National Holidays 2015-2025" type="country">
+    <!-- http://www.officeholidays.com/countries/france/ -->
+    <!-- and official french gouv api https://api.gouv.fr/les-api/jours-feries -->
+
+    <!-- recurring -->
+    <date year="" month="1" date="1" type="HOLIDAY"><![CDATA[1er janvier]]></date>
+    <date year="" month="5" date="1" type="HOLIDAY"><![CDATA[1er mai]]></date>
+    <date year="" month="5" date="8" type="HOLIDAY"><![CDATA[8 mai]]></date>
+    <date year="" month="5" date="28" type="HOLIDAY"><![CDATA[Abolition de l'esclavage]]></date>
+    <date year="" month="7" date="14" type="HOLIDAY"><![CDATA[14 juillet]]></date>
+    <date year="" month="8" date="15" type="HOLIDAY"><![CDATA[Assomption]]></date>
+    <date year="" month="11" date="1" type="HOLIDAY"><![CDATA[Toussaint]]></date>
+    <date year="" month="11" date="11" type="HOLIDAY"><![CDATA[11 novembre]]></date>
+    <date year="" month="12" date="25" type="HOLIDAY"><![CDATA[Jour de Noël]]></date>
+
+
+    <!-- 2015 -->
+    <date year="2015" month="4" date="6" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2015" month="5" date="14" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2015" month="5" date="25" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2016 -->
+    <date year="2016" month="3" date="28" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2016" month="5" date="5" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2016" month="5" date="16" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2017 -->
+    <date year="2017" month="4" date="17" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2017" month="5" date="25" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2017" month="6" date="5" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2018 -->
+    <date year="2018" month="4" date="2" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2018" month="5" date="10" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2018" month="5" date="21" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2019 -->
+    <date year="2019" month="4" date="22" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2019" month="5" date="30" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2019" month="6" date="10" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2020 -->
+    <date year="2020" month="4" date="13" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2020" month="5" date="21" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2020" month="6" date="1" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2021 -->
+    <date year="2021" month="4" date="5" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2021" month="5" date="13" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2021" month="5" date="24" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2022 -->
+    <date year="2022" month="4" date="18" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2022" month="5" date="26" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2022" month="6" date="6" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2023 -->
+    <date year="2023" month="4" date="10" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2023" month="5" date="18" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2023" month="5" date="29" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2024 -->
+    <date year="2024" month="4" date="1" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2024" month="5" date="9" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2024" month="5" date="20" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2025 -->
+    <date year="2025" month="4" date="21" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2025" month="5" date="29" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2025" month="6" date="9" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+</calendar>

--- a/src/main/resources/calendars/i18n_fr_saint_pierre_et_miquelon.calendar
+++ b/src/main/resources/calendars/i18n_fr_saint_pierre_et_miquelon.calendar
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<calendar id="fr.saint-pierre-et-miquelon" name="France (Saint-Pierre-et-Miquelon) National Holidays 2015-2025" type="country">
+    <!-- http://www.officeholidays.com/countries/france/ -->
+    <!-- and official french gouv api https://api.gouv.fr/les-api/jours-feries -->
+
+    <!-- recurring -->
+    <date year="" month="1" date="1" type="HOLIDAY"><![CDATA[1er janvier]]></date>
+    <date year="" month="5" date="1" type="HOLIDAY"><![CDATA[1er mai]]></date>
+    <date year="" month="5" date="8" type="HOLIDAY"><![CDATA[8 mai]]></date>
+    <date year="" month="5" date="28" type="HOLIDAY"><![CDATA[Abolition de l'esclavage]]></date>
+    <date year="" month="7" date="14" type="HOLIDAY"><![CDATA[14 juillet]]></date>
+    <date year="" month="8" date="15" type="HOLIDAY"><![CDATA[Assomption]]></date>
+    <date year="" month="11" date="1" type="HOLIDAY"><![CDATA[Toussaint]]></date>
+    <date year="" month="11" date="11" type="HOLIDAY"><![CDATA[11 novembre]]></date>
+    <date year="" month="12" date="25" type="HOLIDAY"><![CDATA[Jour de Noël]]></date>
+
+
+    <!-- 2015 -->
+    <date year="2015" month="4" date="6" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2015" month="5" date="14" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2015" month="5" date="25" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2016 -->
+    <date year="2016" month="3" date="28" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2016" month="5" date="5" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2016" month="5" date="16" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2017 -->
+    <date year="2017" month="4" date="17" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2017" month="5" date="25" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2017" month="6" date="5" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2018 -->
+    <date year="2018" month="4" date="2" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2018" month="5" date="10" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2018" month="5" date="21" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2019 -->
+    <date year="2019" month="4" date="22" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2019" month="5" date="30" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2019" month="6" date="10" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2020 -->
+    <date year="2020" month="4" date="13" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2020" month="5" date="21" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2020" month="6" date="1" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2021 -->
+    <date year="2021" month="4" date="5" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2021" month="5" date="13" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2021" month="5" date="24" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2022 -->
+    <date year="2022" month="4" date="18" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2022" month="5" date="26" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2022" month="6" date="6" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2023 -->
+    <date year="2023" month="4" date="10" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2023" month="5" date="18" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2023" month="5" date="29" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2024 -->
+    <date year="2024" month="4" date="1" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2024" month="5" date="9" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2024" month="5" date="20" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2025 -->
+    <date year="2025" month="4" date="21" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2025" month="5" date="29" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2025" month="6" date="9" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+</calendar>

--- a/src/main/resources/calendars/i18n_fr_wallis_et_futuna.calendar
+++ b/src/main/resources/calendars/i18n_fr_wallis_et_futuna.calendar
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<calendar id="fr.wallis-et-futuna" name="France (Wallis-et-Futuna) National Holidays 2015-2025" type="country">
+    <!-- http://www.officeholidays.com/countries/france/ -->
+    <!-- and official french gouv api https://api.gouv.fr/les-api/jours-feries -->
+
+    <!-- recurring -->
+    <date year="" month="1" date="1" type="HOLIDAY"><![CDATA[1er janvier]]></date>
+    <date year="" month="5" date="1" type="HOLIDAY"><![CDATA[1er mai]]></date>
+    <date year="" month="5" date="8" type="HOLIDAY"><![CDATA[8 mai]]></date>
+    <date year="" month="5" date="28" type="HOLIDAY"><![CDATA[Abolition de l'esclavage]]></date>
+    <date year="" month="7" date="14" type="HOLIDAY"><![CDATA[14 juillet]]></date>
+    <date year="" month="8" date="15" type="HOLIDAY"><![CDATA[Assomption]]></date>
+    <date year="" month="11" date="1" type="HOLIDAY"><![CDATA[Toussaint]]></date>
+    <date year="" month="11" date="11" type="HOLIDAY"><![CDATA[11 novembre]]></date>
+    <date year="" month="12" date="25" type="HOLIDAY"><![CDATA[Jour de Noël]]></date>
+
+
+    <!-- 2015 -->
+    <date year="2015" month="4" date="6" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2015" month="5" date="14" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2015" month="5" date="25" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2016 -->
+    <date year="2016" month="3" date="28" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2016" month="5" date="5" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2016" month="5" date="16" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2017 -->
+    <date year="2017" month="4" date="17" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2017" month="5" date="25" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2017" month="6" date="5" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2018 -->
+    <date year="2018" month="4" date="2" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2018" month="5" date="10" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2018" month="5" date="21" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2019 -->
+    <date year="2019" month="4" date="22" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2019" month="5" date="30" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2019" month="6" date="10" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2020 -->
+    <date year="2020" month="4" date="13" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2020" month="5" date="21" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2020" month="6" date="1" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2021 -->
+    <date year="2021" month="4" date="5" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2021" month="5" date="13" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2021" month="5" date="24" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2022 -->
+    <date year="2022" month="4" date="18" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2022" month="5" date="26" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2022" month="6" date="6" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2023 -->
+    <date year="2023" month="4" date="10" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2023" month="5" date="18" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2023" month="5" date="29" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2024 -->
+    <date year="2024" month="4" date="1" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2024" month="5" date="9" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2024" month="5" date="20" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+    <!-- 2025 -->
+    <date year="2025" month="4" date="21" type="HOLIDAY"><![CDATA[Lundi de Pâques]]></date>
+    <date year="2025" month="5" date="29" type="HOLIDAY"><![CDATA[Ascension]]></date>
+    <date year="2025" month="6" date="9" type="HOLIDAY"><![CDATA[Lundi de Pentecôte]]></date>
+
+</calendar>


### PR DESCRIPTION
Based on the official french government API https://api.gouv.fr/les-api/jours-feries

Updat the global french calendar, and add the specific regional calendars:
- Alsace Moselle
- Guadeloupe
- Guyane
- La Réunion
- Martinique
- Mayotte
- Saint-Pierre-et-Miquelon
- Saint-Martin
- Saint-Barthélemy
- Nouvelle-Calédonie
- Polynésie française
- Wallis et Futuna