### PR TITLE
Added nl holidays for 2022 and 2023. fixes #2105

### DIFF
--- a/src/main/resources/calendars/i18n_nl.calendar
+++ b/src/main/resources/calendars/i18n_nl.calendar
@@ -6,7 +6,7 @@
 
       <date year="" month="1" date="1"><![CDATA[Nieuwjaarsdag]]></date>
       <date year="" month="4" date="27"><![CDATA[Koningsdag]]></date>
-      <date year="" month="5" date="5"><![CDATA[Bevrijdingsdag]]></date>
+      <date year="" month="5" date="5" type="NEUTRAL"><![CDATA[Bevrijdingsdag]]></date>
       <date year="" month="12" date="25"><![CDATA[Eerste Kerstdag]]></date>
       <date year="" month="12" date="26"><![CDATA[Tweede Kerstdag]]></date>
 

--- a/src/main/resources/calendars/i18n_nl.calendar
+++ b/src/main/resources/calendars/i18n_nl.calendar
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <calendar id="NL" name="Netherlands Holidays 2018-2021" type="country">
-<!-- http://www.officeholidays.com/countries/netherlands/2012.asp -->
-<!-- http://calendar.retira.eu/public-holidays/netherlands/2012/ -->
+      <!-- http://www.officeholidays.com/countries/netherlands/2012.asp -->
+      <!-- http://calendar.retira.eu/public-holidays/netherlands/2012/ -->
+      <!-- https://www.vakantiedagennederland.nl/2023/ -->
 
       <date year="" month="1" date="1"><![CDATA[Nieuwjaarsdag]]></date>
       <date year="" month="4" date="27"><![CDATA[Koningsdag]]></date>
+      <date year="" month="5" date="5"><![CDATA[Bevrijdingsdag]]></date>
       <date year="" month="12" date="25"><![CDATA[Eerste Kerstdag]]></date>
       <date year="" month="12" date="26"><![CDATA[Tweede Kerstdag]]></date>
 
@@ -44,4 +46,21 @@
       <date year="2021" month="5" date="31"><![CDATA[Eerste Pinksterdag]]></date>
       <date year="2021" month="6" date="1"><![CDATA[Tweede Pinksterdag]]></date>
 
+      <date year="2022" month="2" date="27"><![CDATA[Carnaval]]></date>
+      <date year="2022" month="2" date="28"><![CDATA[Carnaval]]></date>
+      <date year="2022" month="3" date="1"><![CDATA[Carnaval]]></date>
+      <date year="2022" month="4" date="17"><![CDATA[Eerste Paasdag]]></date>
+      <date year="2022" month="4" date="18"><![CDATA[Tweede Paasdag]]></date>
+      <date year="2022" month="5" date="26"><![CDATA[Hemelvaart]]></date>
+      <date year="2022" month="6" date="5"><![CDATA[Eerste Pinksterdag]]></date>
+      <date year="2022" month="6" date="6"><![CDATA[Tweede Pinksterdag]]></date>
+
+      <date year="2023" month="2" date="19"><![CDATA[Carnaval]]></date>
+      <date year="2023" month="2" date="20"><![CDATA[Carnaval]]></date>
+      <date year="2023" month="2" date="21"><![CDATA[Carnaval]]></date>
+      <date year="2023" month="4" date="9"><![CDATA[Eerste Paasdag]]></date>
+      <date year="2023" month="4" date="10"><![CDATA[Tweede Paasdag]]></date>
+      <date year="2023" month="5" date="18"><![CDATA[Hemelvaart]]></date>
+      <date year="2023" month="5" date="28"><![CDATA[Eerste Pinksterdag]]></date>
+      <date year="2023" month="5" date="29"><![CDATA[Tweede Pinksterdag]]></date>
 </calendar>


### PR DESCRIPTION
- Added holidays 2022 and 2023
- Added bevrijdingsdag (liberationday) as recurring holiday