### PR TITLE
Add dates for Easter Monday in the Italian holiday calendar

### DIFF
--- a/src/main/resources/calendars/i18n_it.calendar
+++ b/src/main/resources/calendars/i18n_it.calendar
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<calendar id="it" name="Italy Bank Holidays 2015-2022" type="country">
+<calendar id="it" name="Italy Bank Holidays 2024-2034" type="country">
 <!-- http://en.wikipedia.org/wiki/Public_holidays_in_Italy -->
 <!-- http://www.officeholidays.com/countries/italy/index.php -->
 <!-- http://www.timeanddate.com/holidays/italy/ -->
+<!-- https://www.calendario-365.it/giorni-festivi/luned%C3%AC-dell%27angelo-o-pasquetta.html -->
 
 	<date year="" month="01" date="01"><![CDATA[New Years Day]]></date>
 	<date year="" month="01" date="06"><![CDATA[Epiphany]]></date>
@@ -33,6 +34,18 @@
 	<date year="2020" month="04" date="13"><![CDATA[Easter Monday]]></date>
 	<date year="2021" month="04" date="05"><![CDATA[Easter Monday]]></date>
 	<date year="2022" month="04" date="18"><![CDATA[Easter Monday]]></date>
+	<date year="2023" month="04" date="10"><![CDATA[Easter Monday]]></date>
+	<date year="2024" month="04" date="01"><![CDATA[Easter Monday]]></date>
+	<date year="2025" month="04" date="21"><![CDATA[Easter Monday]]></date>
+	<date year="2026" month="04" date="06"><![CDATA[Easter Monday]]></date>
+	<date year="2027" month="03" date="29"><![CDATA[Easter Monday]]></date>
+	<date year="2028" month="04" date="17"><![CDATA[Easter Monday]]></date>
+	<date year="2029" month="04" date="02"><![CDATA[Easter Monday]]></date>
+	<date year="2030" month="04" date="22"><![CDATA[Easter Monday]]></date>
+	<date year="2031" month="04" date="14"><![CDATA[Easter Monday]]></date>
+	<date year="2032" month="03" date="29"><![CDATA[Easter Monday]]></date>
+	<date year="2033" month="04" date="18"><![CDATA[Easter Monday]]></date>
+	<date year="2034" month="04" date="10"><![CDATA[Easter Monday]]></date>
 
 
 </calendar>


### PR DESCRIPTION
Dates added until 2034.
Calendar taken from: https://www.calendario-365.it/giorni-festivi/luned%C3%AC-dell%27angelo-o-pasquetta.html